### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,17 @@ php:
   - 7.2
   - nightly
 
+matrix:
+  allow_failures:
+    - php: nightly
+
 install:
   - if [[ "$TRAVIS_PHP_VERSION" != "nightly" ]]; then phpenv config-rm xdebug.ini; fi
-  - travis_retry composer self-update
-  - travis_retry composer install --prefer-dist --dev
+  - travis_retry composer install --prefer-dist
 
 script:
   - mkdir -p build/logs
-  - phpdbg -qrr vendor/bin/phpunit -c phpunit.xml.dist
+  - phpdbg -qrr vendor/bin/phpunit
 
 after_script:
   - travis_retry vendor/bin/php-coveralls -v

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
 
 install:
   - if [[ "$TRAVIS_PHP_VERSION" != "nightly" ]]; then phpenv config-rm xdebug.ini; fi
-  - travis_retry composer install --prefer-dist
+  - travis_retry composer update --prefer-dist -n
 
 script:
   - mkdir -p build/logs

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,11 @@
             "kornrunner\\": "src"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "kornrunner\\": "test"
+        }
+    },
     "require-dev": {
         "phpunit/phpunit": "~7",
         "satooshi/php-coveralls": "~2"

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         }
     ],
     "require": {
-        "php": ">=7.1.0"
+        "php": ">=7.1.0",
+        "ext-mbstring": "*"
     },
     "autoload": {
         "psr-4": {

--- a/test/KeccakTest.php
+++ b/test/KeccakTest.php
@@ -6,7 +6,6 @@ namespace kornrunner;
  *@see https://gist.github.com/Souptacular/f50128d63b5188490fa2
  */
 
-use kornrunner\Keccak;
 use PHPUnit\Framework\TestCase;
 
 class KeccakTest extends TestCase

--- a/test/KeccakTest.php
+++ b/test/KeccakTest.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace kornrunner;
+
 /**
  *@see https://gist.github.com/Souptacular/f50128d63b5188490fa2
  */
@@ -15,7 +17,7 @@ class KeccakTest extends TestCase
 
     public static function setUpBeforeClass() {
         parent::setUpBeforeClass();
-        $class = new ReflectionClass(Keccak::class);
+        $class = new \ReflectionClass(Keccak::class);
         self::$x64 = $class->getProperty('x64');
         self::$x64->setAccessible(true);
     }
@@ -125,14 +127,14 @@ class KeccakTest extends TestCase
 
     public function testUnsupportedHashOutputSize()
     {
-        $this->expectException('Exception');
+        $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Unsupported Keccak Hash output size.');
         Keccak::hash('', 225);
     }
 
     public function testUnsupportedShakeSecurityLevel()
     {
-        $this->expectException('Exception');
+        $this->expectException(\Exception::class);
         $this->expectExceptionMessage('Unsupported Keccak Shake security level.');
         Keccak::shake('', 129, 256);
     }


### PR DESCRIPTION
# Changed log

- Set the ```php-nightly``` in allow_failures setting when executing the Travis build.
- Use the ```::class``` for the ```\Exception``` class.
- Check the ```ext-mbstring``` when executing the Composer command.
- The ```composer self-update``` is executed by default in Travis build.
- The ```--dev``` option in composer command is deprecated.
- Use the ```composer update --prefer-dist -n``` to update the dependencies for the different PHP versions tests because the ```composer.lock``` will cache the dependencies version when executing the ```composer install```.
- Add the ```autoload-dev``` to load the related ```Test.php``` automatically.